### PR TITLE
CF-3744 Replace SHA-1 with SHA-256 to fix CWE-327 weak crypto

### DIFF
--- a/importer.go
+++ b/importer.go
@@ -184,7 +184,7 @@ func (this *Importer) PutFormXobjects() map[string]int {
 	return res
 }
 
-// Put form xobjects and get back a map of template names (e.g. /GOFPDITPL1) and their object ids (sha1 hash)
+// Put form xobjects and get back a map of template names (e.g. /GOFPDITPL1) and their object ids (sha256 hash)
 func (this *Importer) PutFormXobjectsUnordered() map[string]string {
 	this.GetWriter().SetUseHash(true)
 	res := make(map[string]string, 0)
@@ -208,9 +208,9 @@ func (this *Importer) GetImportedObjects() map[int]string {
 	return res
 }
 
-// Get object ids (sha1 hash) and their contents ([]byte)
+// Get object ids (sha256 hash) and their contents ([]byte)
 // The contents may have references to other object hashes which will need to be replaced by the pdf generator library
-// The positions of the hashes (sha1 - 40 characters) can be obtained by calling GetImportedObjHashPos()
+// The positions of the hashes (sha256 - 64 characters) can be obtained by calling GetImportedObjHashPos()
 func (this *Importer) GetImportedObjectsUnordered() map[string][]byte {
 	res := make(map[string][]byte, 0)
 	pdfObjIdBytes := this.GetWriter().GetImportedObjects()
@@ -220,7 +220,7 @@ func (this *Importer) GetImportedObjectsUnordered() map[string][]byte {
 	return res
 }
 
-// Get the positions of the hashes (sha1 - 40 characters) within each object, to be replaced with
+// Get the positions of the hashes (sha256 - 64 characters) within each object, to be replaced with
 // actual objects ids by the pdf generator library
 func (this *Importer) GetImportedObjHashPos() map[string]map[int]string {
 	res := make(map[string]map[int]string, 0)

--- a/writer.go
+++ b/writer.go
@@ -4,7 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"compress/zlib"
-	"crypto/sha1"
+	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
 	"math"
@@ -103,7 +103,7 @@ func (this *PdfWriter) GetImportedObjects() map[*PdfObjectId][]byte {
 	return this.written_objs
 }
 
-// For each object (uniquely identified by a sha1 hash), return the positions
+// For each object (uniquely identified by a sha256 hash), return the positions
 // of each hash within the object, to be replaced with pdf object ids (integers)
 func (this *PdfWriter) GetImportedObjHashPos() map[*PdfObjectId]map[int]string {
 	return this.written_obj_pos
@@ -236,7 +236,7 @@ func (this *PdfWriter) endObj() {
 }
 
 func (this *PdfWriter) shaOfInt(i int) string {
-	hasher := sha1.New()
+	hasher := sha256.New()
 	hasher.Write([]byte(fmt.Sprintf("%d-%d-%s", this.tpl_id_offset, i, this.r.sourceFile)))
 	sha := hex.EncodeToString(hasher.Sum(nil))
 	return sha


### PR DESCRIPTION
Replace crypto/sha1 with crypto/sha256 in shaOfInt() used for PDF object ID placeholders. Update all comments referencing sha1 hash lengths (40 chars -> 64 chars).